### PR TITLE
Add Matzatea project: page, translations, and docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,103 @@
+# GIFLABS - Regras de Desenvolvimento para Cursor
+
+## Visão Geral do Projeto
+Este é um site institucional do GIFLABS desenvolvido com Next.js 14 (App Router), TypeScript, Tailwind CSS e Shadcn UI. O projeto implementa um sistema de internacionalização completo (Português/Inglês) e segue padrões modernos de desenvolvimento web.
+
+## Filosofia de Design Atual
+- **ESTILO ATUAL**: Site extremamente simples e clean, focado em simplicidade e legibilidade
+- **FUTURO**: Serão adicionados efeitos visuais, imagens e vídeos gradualmente
+- **PRINCÍPIO**: Manter a elegância e simplicidade como base, expandindo com cuidado
+
+## Estrutura do Projeto
+O código-fonte está organizado em `/src/` com a seguinte estrutura:
+
+- `/src/app/` - Páginas do App Router
+- `/src/components/` - Componentes reutilizáveis
+- `/src/contexts/` - Contextos React (incluindo internacionalização)
+- `/src/contexts/translations/` - Arquivos de tradução (PT/EN)
+- `/src/lib/` - Utilitários e configurações
+
+## Sistema de Internacionalização
+- Usa Context API customizado (LanguageContext)
+- Função `t(key)` para traduções
+- Arquivos de tradução em TypeScript (não JSON)
+- Idiomas: Português (pt) e Inglês (en)
+- Português é o idioma padrão
+
+## Estrutura da Página Principal
+- **Hero Section**: Título principal, descrição e CTA
+- **Sobre Section**: Descrição do GIFLABS, Missão, Visão e Valores
+- **Projetos Section**: Grid de cards dos projetos atuais
+- **Equipe Section**: Perfis dos membros com badges e links sociais
+
+## Sistema de Projetos
+Cada projeto tem:
+- Card na página inicial com ícone, título e descrição
+- Página dedicada em `/src/app/[nome-projeto]/page.tsx`
+- Arquivo de traduções específico
+- Link direto do card para a página
+
+## Regras para Modificações
+
+### Ao Adicionar Novos Projetos:
+1. Adicionar entrada no array `projects` em `src/app/page.tsx`
+2. Adicionar traduções em `src/contexts/translations/home.ts` para ambos os idiomas
+3. Criar página do projeto em `src/app/[nome-projeto]/page.tsx`
+4. Criar arquivo de traduções em `translations/`
+5. Importar novas traduções em `LanguageContext.tsx`
+
+### Ao Modificar Componentes:
+1. Sempre usar TypeScript com tipagem adequada
+2. Usar função `t()` para todos os textos (internacionalização)
+3. Seguir padrão mobile-first com Tailwind CSS
+4. Manter padrões de acessibilidade ARIA
+5. **PRESERVAR** o design simples e clean atual
+
+### Ao Adicionar Novos Recursos Visuais:
+1. **IMAGENS**: Usar Next.js Image com otimização automática
+2. **VÍDEOS**: Implementar lazy loading e controles responsivos
+3. **EFEITOS**: Manter sutis e não interferir na legibilidade
+4. **PERFORMANCE**: Sempre otimizar para não comprometer a velocidade
+
+### Convenções de Nomenclatura:
+- Arquivos: kebab-case (`digital-education-app.ts`)
+- Componentes: PascalCase (`GifLabsSite`)
+- Funções: camelCase (`useLanguage`)
+- Constantes: camelCase (`homeTranslations`)
+
+## Padrões Técnicos
+- Next.js 14 com App Router
+- TypeScript estrito
+- Tailwind CSS para estilização
+- Shadcn UI para componentes base
+- Lucide React para ícones
+- Context API para estado global
+
+## Estrutura de Traduções
+```typescript
+// Exemplo de chave: t("home.projects.cards.education_app.title")
+export const homeTranslations = {
+  pt: { home: { projects: { cards: { education_app: { title: "..." } } } } },
+  en: { home: { projects: { cards: { education_app: { title: "..." } } } } }
+}
+```
+
+## Navegação e UX
+- **Navegação interna**: Scroll suave entre seções com IDs
+- **Navegação entre páginas**: Links diretos para projetos
+- **Responsividade**: Mobile-first approach
+- **Acessibilidade**: Sempre manter padrões ARIA
+
+## Considerações de Performance
+- **Atual**: Site estático e rápido
+- **Futuro**: Manter otimizações ao adicionar mídia
+- **Lazy Loading**: Implementar para imagens e vídeos
+- **Bundle Size**: Monitorar ao adicionar bibliotecas
+
+## IMPORTANTE
+- NUNCA alterar textos originais - sempre usar sistema de tradução
+- Sempre manter responsividade mobile-first
+- Sempre testar em ambos os idiomas
+- **PRESERVAR** a simplicidade e elegância atual do design
+- **EXPANDIR** gradualmente com novos recursos visuais
+- Consultar PROJECT_STRUCTURE.md para detalhes técnicos completos

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,0 +1,351 @@
+# GIFLABS - Documentação Completa da Estrutura do Projeto
+
+## Visão Geral
+O GIFLABS é um site institucional desenvolvido com Next.js 14 (App Router), TypeScript, Tailwind CSS e Shadcn UI. O projeto implementa um sistema de internacionalização completo (Português/Inglês) e segue padrões modernos de desenvolvimento web.
+
+## Arquitetura Técnica
+
+### Framework e Tecnologias
+- **Next.js 14** com App Router
+- **TypeScript** para tipagem estática
+- **Tailwind CSS** para estilização
+- **Shadcn UI** para componentes base
+- **React 18** com hooks modernos
+- **Lucide React** para ícones
+
+### Estrutura de Diretórios
+```
+giflabs/
+├── src/
+│   ├── app/                    # App Router do Next.js
+│   │   ├── page.tsx           # Página inicial (landing page)
+│   │   ├── digital-education-app/
+│   │   │   └── page.tsx       # Página do projeto Digital Education App
+│   │   ├── serie-if/
+│   │   │   └── page.tsx       # Página do projeto Série IF
+│   │   ├── virtualia/
+│   │   │   └── page.tsx       # Página do projeto Virtualia
+│   │   ├── arqueologia-digital/
+│   │   │   └── page.tsx       # Página do projeto Arqueologia Digital
+│   │   ├── the-philosophers-dao/
+│   │   │   └── page.tsx       # Página do projeto The Philosophers DAO
+│   │   └── metaverso/
+│   │       └── page.tsx       # Página do projeto Metaverso
+│   ├── components/             # Componentes reutilizáveis
+│   │   ├── layout/            # Componentes de layout
+│   │   │   ├── header.tsx     # Cabeçalho da aplicação
+│   │   │   ├── footer.tsx     # Rodapé da aplicação
+│   │   │   └── language-switcher.tsx # Seletor de idioma
+│   │   └── ui/                # Componentes base do Shadcn UI
+│   ├── contexts/              # Contextos React
+│   │   ├── LanguageContext.tsx # Contexto de internacionalização
+│   │   └── translations/      # Arquivos de tradução
+│   │       ├── home.ts        # Traduções da página inicial
+│   │       ├── header-footer.ts # Traduções de cabeçalho/rodapé
+│   │       ├── serie-if.ts    # Traduções da página Série IF
+│   │       ├── digital-education-app.ts # Traduções Digital Education App
+│   │       ├── virtualia.ts   # Traduções da página Virtualia
+│   │       ├── metaverso.ts   # Traduções da página Metaverso
+│   │       ├── arqueologia-digital.ts # Traduções Arqueologia Digital
+│   │       └── the-philosophers-dao.ts # Traduções The Philosophers DAO
+│   └── lib/                   # Utilitários e configurações
+├── public/                     # Arquivos estáticos
+├── components.json             # Configuração do Shadcn UI
+├── next.config.mjs            # Configuração do Next.js
+├── tailwind.config.ts         # Configuração do Tailwind CSS
+├── tsconfig.json              # Configuração do TypeScript
+└── package.json               # Dependências do projeto
+```
+
+## Sistema de Internacionalização (i18n)
+
+### Arquitetura
+O projeto utiliza um sistema de internacionalização customizado baseado em Context API do React, não dependendo de bibliotecas externas como `next-i18next`.
+
+### Componentes Principais
+
+#### LanguageContext.tsx
+- **Localização**: `src/contexts/LanguageContext.tsx`
+- **Funcionalidade**: Gerencia o estado do idioma e fornece a função de tradução
+- **Estado**: Idioma atual (pt/en) persistido no localStorage
+- **Padrão**: Português (pt) como idioma padrão
+- **Função Principal**: `t(key: string)` - busca traduções usando chaves aninhadas
+
+#### Estrutura de Traduções
+```typescript
+// Exemplo de estrutura em home.ts
+export const homeTranslations = {
+  pt: {
+    home: {
+      projects: {
+        title: "Nossos Projetos",
+        cards: {
+          education_app: {
+            title: "Digital Education App",
+            description: "Descrição em português..."
+          }
+        }
+      }
+    }
+  },
+  en: {
+    home: {
+      projects: {
+        title: "Our Projects",
+        cards: {
+          education_app: {
+            title: "Digital Education App",
+            description: "Description in English..."
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Como Usar Traduções
+```typescript
+import { useLanguage } from "@/contexts/LanguageContext";
+
+function MyComponent() {
+  const { t } = useLanguage();
+  
+  return (
+    <h1>{t("home.projects.title")}</h1>
+  );
+}
+```
+
+## Estrutura da Página Principal
+
+### Arquivo Principal
+- **Localização**: `src/app/page.tsx`
+- **Componente**: `GifLabsSite`
+- **Tipo**: Client Component (usa "use client")
+
+### Seções da Página
+1. **Hero Section** (`id="home"`)
+   - Título principal e descrição
+   - Botão CTA que leva para a seção de projetos
+   - Background com gradiente e grid animado
+
+2. **Sobre Section** (`id="sobre"`)
+   - Descrição do GIFLABS
+   - Missão, Visão e Valores
+   - Layout em grid de 3 colunas
+
+3. **Projetos Section** (`id="projetos"`)
+   - Renderizada pelo componente `Projects`
+   - Grid responsivo de cards de projetos
+   - Cada card tem ícone, título, descrição e link
+
+4. **Equipe Section** (`id="equipe"`)
+   - Membros da equipe com perfis
+   - Badges de especialização
+   - Links para redes sociais e currículos
+
+### Componente Projects
+```typescript
+const projects = [
+  {
+    id: "education-app",
+    iconName: "GraduationCap",
+    link: "/digital-education-app",
+  },
+  // ... outros projetos
+];
+```
+
+**IMPORTANTE**: Para adicionar um novo projeto, é necessário:
+1. Adicionar entrada no array `projects`
+2. Adicionar traduções em `home.ts` para ambos os idiomas
+3. Criar a página do projeto em `src/app/[nome-do-projeto]/page.tsx`
+
+## Sistema de Navegação
+
+### Navegação Interna (Scroll)
+- Links âncora para seções: `/#projetos`, `/#equipe`, etc.
+- Scroll suave entre seções
+- IDs de seção: `home`, `sobre`, `projetos`, `equipe`
+
+### Navegação entre Páginas
+- Cada projeto tem sua própria rota
+- Links externos para redes sociais e currículos
+- Navegação por breadcrumbs implícita
+
+## Padrões de Desenvolvimento
+
+### Convenções de Nomenclatura
+- **Arquivos**: kebab-case (`digital-education-app.ts`)
+- **Componentes**: PascalCase (`GifLabsSite`)
+- **Funções**: camelCase (`useLanguage`)
+- **Constantes**: camelCase (`homeTranslations`)
+
+### Estrutura de Componentes
+```typescript
+// Ordem recomendada:
+export default function ComponentName() {
+  // 1. Hooks e estado
+  // 2. Lógica de negócio
+  // 3. Renderização
+  return (
+    <div>
+      {/* JSX */}
+    </div>
+  );
+}
+```
+
+### Estilização
+- **Tailwind CSS** como framework principal
+- **Mobile-first** approach
+- **Componentes Shadcn UI** para elementos base
+- **Customização** através de classes Tailwind
+
+## Configurações Importantes
+
+### Next.js
+```javascript
+// next.config.mjs
+const nextConfig = {
+  eslint: { ignoreDuringBuilds: true },
+  typescript: { ignoreBuildErrors: true },
+  images: { unoptimized: true }
+};
+```
+
+### Tailwind CSS
+- Configuração customizada em `tailwind.config.ts`
+- Sistema de cores neutras como base
+- Grid responsivo e utilitários de espaçamento
+
+### TypeScript
+- Configuração estrita em `tsconfig.json`
+- Path mapping para imports (`@/components`, `@/contexts`)
+
+## Fluxo de Dados
+
+### Estado Global
+- **Idioma**: Gerenciado pelo LanguageContext
+- **Persistência**: localStorage para preferência de idioma
+- **Reatividade**: Context API para atualizações em tempo real
+
+### Props e Comunicação
+- Componentes recebem dados via props quando necessário
+- Context API para dados compartilhados (idioma)
+- Dados estáticos definidos localmente nos componentes
+
+## Considerações de Performance
+
+### Otimizações Implementadas
+- **Lazy Loading**: Imagens otimizadas com Next.js Image
+- **CSS-in-JS**: Tailwind CSS com purging automático
+- **Bundle Splitting**: Next.js automaticamente
+- **Static Generation**: Páginas estáticas quando possível
+
+### Boas Práticas
+- Uso de `use client` apenas quando necessário
+- Componentes funcionais com hooks
+- Memoização quando apropriado
+- Imports otimizados
+
+## Estrutura de Dados
+
+### Projetos
+```typescript
+interface Project {
+  id: string;           // Identificador único
+  iconName: string;     // Nome do ícone Lucide
+  link: string;         // Rota da página do projeto
+}
+```
+
+### Membros da Equipe
+```typescript
+interface TeamMember {
+  id: string;           // Identificador único
+  iconName: string;     // Nome do ícone Lucide
+  lattes: string;       // Link para currículo Lattes
+  github: string;       // Link para GitHub
+  linkedin: string;     // Link para LinkedIn
+  twitter: string;      // Link para Twitter
+  badges: string[];     // Array de badges de especialização
+}
+```
+
+## Regras para Modificações
+
+### Ao Adicionar Novos Projetos
+1. **Array de Projetos**: Adicionar entrada em `projects` em `page.tsx`
+2. **Traduções**: Adicionar entradas em `home.ts` para ambos os idiomas
+3. **Página**: Criar `src/app/[nome-projeto]/page.tsx`
+4. **Traduções da Página**: Criar arquivo em `translations/`
+5. **Context**: Importar novas traduções em `LanguageContext.tsx`
+
+### Ao Modificar Componentes
+1. **Manter Tipagem**: Sempre usar TypeScript
+2. **Internacionalização**: Usar função `t()` para todos os textos
+3. **Responsividade**: Seguir padrão mobile-first
+4. **Acessibilidade**: Manter padrões ARIA e semânticos
+
+### Ao Adicionar Novos Idiomas
+1. **Context**: Modificar `LanguageContext.tsx`
+2. **Traduções**: Adicionar novo idioma em todos os arquivos de tradução
+3. **Switcher**: Atualizar `language-switcher.tsx`
+4. **Validação**: Atualizar lógica de validação de idioma
+
+## Dependências Principais
+
+### Produção
+- `next`: ^14.0.0
+- `react`: ^18.0.0
+- `typescript`: ^5.0.0
+- `tailwindcss`: ^3.0.0
+- `lucide-react`: Para ícones
+- `@radix-ui/*`: Componentes base do Shadcn UI
+
+### Desenvolvimento
+- `@types/node`: Tipos do Node.js
+- `@types/react`: Tipos do React
+- `eslint`: Linting
+- `postcss`: Processamento CSS
+
+## Comandos Úteis
+
+### Desenvolvimento
+```bash
+npm run dev          # Iniciar servidor de desenvolvimento
+npm run build        # Build de produção
+npm run start        # Iniciar servidor de produção
+npm run lint         # Executar ESLint
+```
+
+### Instalação
+```bash
+npm install          # Instalar dependências
+npm run build       # Build antes de deploy
+```
+
+## Considerações de Deploy
+
+### Build
+- Next.js gera build otimizado
+- Imagens são otimizadas automaticamente
+- CSS é purgado e minificado
+- JavaScript é code-splitted
+
+### Arquivos Estáticos
+- Localizados em `/public`
+- Acessíveis diretamente via URL
+- Otimizados pelo Next.js
+
+## Conclusão
+
+Esta documentação serve como guia completo para qualquer modificação no projeto GIFLABS. Seguir estas regras e padrões garante consistência, manutenibilidade e qualidade do código. Sempre consulte esta documentação antes de implementar mudanças para manter a integridade da arquitetura existente.
+
+---
+
+**Última Atualização**: Dezembro 2025  
+**Versão do Projeto**: 1.0.0  
+**Mantenedor**: Equipe GIFLABS

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ O projeto é compatível com:
 
 ## 🔗 Links Importantes
 
-- **Website**: [GIFLABS](http://localhost:3000)
+- **Website**: [GIFLABS](http://giflabs.xyz)
 - **Virtualia Journal**: [virtualiajournal.com](https://www.virtualiajournal.com/)
 - **Canal YouTube**: [The Philosophers DAO](https://www.youtube.com/@ThePhilosophersDAOpt)
 - **Série IF**: [UFPel](https://wp.ufpel.edu.br/nepfil/serie-investigacao-filosofica/)

--- a/src/app/matzatea/page.tsx
+++ b/src/app/matzatea/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import React from "react";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, BookOpen, Palette, User, Award, Users, Globe } from "lucide-react";
+import Link from "next/link";
+
+export default function MatzateaPage() {
+  const { t } = useLanguage();
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      {/* Header */}
+      <div className="bg-neutral-900 text-white py-6">
+        <div className="container mx-auto px-6">
+          <Link href="/" className="inline-flex items-center text-neutral-300 hover:text-white transition-colors">
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            {t("matzatea.back_to_home")}
+          </Link>
+        </div>
+      </div>
+
+      {/* Hero Section */}
+      <section className="py-20 bg-gradient-to-br from-neutral-100 to-neutral-200">
+        <div className="container mx-auto px-6 text-center">
+          <div className="max-w-4xl mx-auto">
+            <h1 className="text-5xl md:text-6xl font-bold mb-6 text-neutral-900">
+              {t("matzatea.hero.title")}
+            </h1>
+            <p className="text-xl md:text-2xl text-neutral-600 mb-8 font-light leading-relaxed">
+              {t("matzatea.hero.subtitle")}
+            </p>
+            <div className="flex flex-wrap gap-4 justify-center">
+              <Badge variant="secondary" className="text-lg px-4 py-2">
+                <BookOpen className="w-4 h-4 mr-2" />
+                {t("matzatea.hero.badges.literary")}
+              </Badge>
+              <Badge variant="secondary" className="text-lg px-4 py-2">
+                <Palette className="w-4 h-4 mr-2" />
+                {t("matzatea.hero.badges.artistic")}
+              </Badge>
+              <Badge variant="secondary" className="text-lg px-4 py-2">
+                <Globe className="w-4 h-4 mr-2" />
+                {t("matzatea.hero.badges.cultural")}
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* O Projeto Section */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-4xl font-bold mb-8 text-center text-neutral-900">
+              {t("matzatea.project.title")}
+            </h2>
+            <div className="prose prose-lg max-w-none text-neutral-700">
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.project.description")}
+              </p>
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.project.context")}
+              </p>
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.project.collaboration")}
+              </p>
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.project.actions")}
+              </p>
+              <p className="leading-relaxed">
+                {t("matzatea.project.objectives")}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre o Autor Section */}
+      <section className="py-20 bg-neutral-50">
+        <div className="container mx-auto px-6">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-4xl font-bold mb-8 text-center text-neutral-900">
+              {t("matzatea.author.title")}
+            </h2>
+            <div className="bg-white rounded-lg p-8 shadow-sm">
+              <div className="flex items-center mb-6">
+                <div className="w-16 h-16 bg-neutral-100 rounded-full flex items-center justify-center mr-4">
+                  <User className="w-8 h-8 text-neutral-600" />
+                </div>
+                <div>
+                  <h3 className="text-2xl font-bold text-neutral-900">Emanuel Souza</h3>
+                  <p className="text-neutral-600">{t("matzatea.author.roles")}</p>
+                </div>
+              </div>
+              <div className="prose prose-lg max-w-none text-neutral-700">
+                <p className="mb-4 leading-relaxed">
+                  {t("matzatea.author.description")}
+                </p>
+                <p className="mb-4 leading-relaxed">
+                  {t("matzatea.author.technique")}
+                </p>
+                <p className="mb-4 leading-relaxed">
+                  {t("matzatea.author.participations")}
+                </p>
+                <p className="leading-relaxed">
+                  {t("matzatea.author.final")}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Sobre a Artista Section */}
+      <section className="py-20 bg-white">
+        <div className="container mx-auto px-6">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-4xl font-bold mb-8 text-center text-neutral-900">
+              {t("matzatea.artist.title")}
+            </h2>
+            <div className="bg-neutral-50 rounded-lg p-8">
+              <div className="flex items-center mb-6">
+                <div className="w-16 h-16 bg-neutral-100 rounded-full flex items-center justify-center mr-4">
+                  <Palette className="w-8 h-8 text-neutral-600" />
+                </div>
+                <div>
+                  <h3 className="text-2xl font-bold text-neutral-900">Fer Caggiano</h3>
+                  <p className="text-neutral-600">{t("matzatea.artist.roles")}</p>
+                </div>
+              </div>
+              <div className="prose prose-lg max-w-none text-neutral-700">
+                <p className="mb-4 leading-relaxed">
+                  {t("matzatea.artist.description")}
+                </p>
+                <p className="mb-4 leading-relaxed">
+                  {t("matzatea.artist.project")}
+                </p>
+                <p className="leading-relaxed">
+                  {t("matzatea.artist.activities")}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Relevância Cultural Section */}
+      <section className="py-20 bg-neutral-900 text-white">
+        <div className="container mx-auto px-6">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-4xl font-bold mb-8 text-center">
+              {t("matzatea.cultural_relevance.title")}
+            </h2>
+            <div className="prose prose-lg max-w-none text-neutral-300">
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.cultural_relevance.intro")}
+              </p>
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.cultural_relevance.boundaries")}
+              </p>
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.cultural_relevance.expansion")}
+              </p>
+              <p className="leading-relaxed">
+                {t("matzatea.cultural_relevance.initiative")}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Financiamento Section */}
+      <section className="py-20 bg-gradient-to-br from-amber-50 to-orange-50">
+        <div className="container mx-auto px-6">
+          <div className="max-w-4xl mx-auto text-center">
+            <h2 className="text-4xl font-bold mb-6 text-neutral-900">
+              {t("matzatea.funding.title")}
+            </h2>
+            <p className="text-xl text-neutral-600 mb-8 font-light">
+              {t("matzatea.funding.subtitle")}
+            </p>
+            <div className="prose prose-lg max-w-none text-neutral-700">
+              <p className="mb-6 leading-relaxed">
+                {t("matzatea.funding.description")}
+              </p>
+              <p className="text-lg font-medium text-neutral-800">
+                {t("matzatea.funding.final")}
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-20 bg-neutral-900 text-white">
+        <div className="container mx-auto px-6 text-center">
+          <div className="max-w-3xl mx-auto">
+            <h2 className="text-4xl font-bold mb-6">
+              {t("matzatea.cta.title")}
+            </h2>
+            <p className="text-xl text-neutral-300 mb-8">
+              {t("matzatea.cta.description")}
+            </p>
+            <Button
+              size="lg"
+              className="bg-white hover:bg-neutral-100 text-neutral-900 px-8 py-4 text-lg transition-all duration-300"
+            >
+              <Link href="/#projetos">
+                {t("matzatea.cta.button")}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,6 +75,11 @@ const projects = [
     iconName: "Puzzle",
     link: "/metaverso",
   },
+  {
+    id: "matzatea",
+    iconName: "BookOpen",
+    link: "/matzatea",
+  },
 ];
 
 const teamMembers = [

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -11,6 +11,7 @@ import { virtualiaTranslations } from './translations/virtualia';
 import { metaversoTranslations } from './translations/metaverso';
 import { arqueologiaDigitalTranslations } from './translations/arqueologia-digital';
 import { thePhilosophersDaoTranslations } from './translations/the-philosophers-dao';
+import { matzateaTranslations } from './translations/matzatea';
 
 interface LanguageContextType {
   language: string;
@@ -46,7 +47,8 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
         ...virtualiaTranslations.pt,
         ...metaversoTranslations.pt,
         ...arqueologiaDigitalTranslations.pt,
-        ...thePhilosophersDaoTranslations.pt
+        ...thePhilosophersDaoTranslations.pt,
+        ...matzateaTranslations.pt
       },
       en: {
         ...headerFooterTranslations.en,
@@ -56,7 +58,8 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
         ...virtualiaTranslations.en,
         ...metaversoTranslations.en,
         ...arqueologiaDigitalTranslations.en,
-        ...thePhilosophersDaoTranslations.en
+        ...thePhilosophersDaoTranslations.en,
+        ...matzateaTranslations.en
       }
     };
 

--- a/src/contexts/translations/home.ts
+++ b/src/contexts/translations/home.ts
@@ -54,6 +54,10 @@ export const homeTranslations = {
           "metaverso": {
             "title": "Metaverso",
             "description": "Exploramos a estetica, a etica e as narrativas de ambientes digitais com jogos experimentais, galerias de arte e a biblioteca Near Alexandria."
+          },
+          "matzatea": {
+            "title": "Matzatea: um thriller filosófico que desafia a realidade",
+            "description": "Experiência literária imersiva que combina literatura, artes visuais e tecnologia, criando espaços para pensamento filosófico e sensibilidade artística."
           }
         }
       },
@@ -168,6 +172,10 @@ export const homeTranslations = {
           "metaverso": {
             "title": "Metaverse",
             "description": "We explore the aesthetics, ethics, and narratives of digital environments with experimental games, art galleries, and the Near Alexandria library."
+          },
+          "matzatea": {
+            "title": "Matzatea: a philosophical thriller that challenges reality",
+            "description": "Immersive literary experience that combines literature, visual arts, and technology, creating spaces for philosophical thought and artistic sensibility."
           }
         }
       },

--- a/src/contexts/translations/matzatea.ts
+++ b/src/contexts/translations/matzatea.ts
@@ -1,0 +1,112 @@
+export const matzateaTranslations = {
+  pt: {
+    "matzatea": {
+      "back_to_home": "Voltar ao Início",
+      "hero": {
+        "title": "Matzatea",
+        "subtitle": "Um thriller filosófico que desafia a realidade",
+        "badges": {
+          "literary": "Literário",
+          "artistic": "Artístico",
+          "cultural": "Cultural"
+        }
+      },
+      "project": {
+        "title": "O Projeto",
+        "description": "Matzatea é mais que uma obra literária; é uma experiência cultural que articula literatura, artes visuais, tecnologia e formação de leitores. Nascido do desejo de explorar novas formas de narração e conectar-se com o público, o projeto propõe uma imersão estética que vai além dos limites do livro impresso.",
+        "context": "Partindo do romance homônimo, ambientado no Rio de Janeiro de 1994, o projeto se desdobra em ações que promovem o acesso à literatura brasileira contemporânea, o diálogo entre diferentes linguagens artísticas e a democratização do conhecimento.",
+        "collaboration": "Conta com ilustrações e cenários especialmente criados para a obra pela artista visual Fer Caggiano. Matzatea propõe uma leitura sensorial e expandida onde imagem e texto se entrelaçam para potencializar a experiência do leitor. A arte não apenas ilustra, mas interpreta e amplifica os significados da narrativa.",
+        "actions": "O projeto inclui a publicação do livro em versões física e digital, uma série de ações culturais, incluindo oficinas literárias, debates com o autor, encontros com educadores, atividades pedagógicas e a distribuição gratuita de exemplares para bibliotecas públicas, escolas e projetos sociais.",
+        "objectives": "Essas iniciativas visam estimular o pensamento crítico, incentivar a leitura e valorizar a produção literária independente."
+      },
+      "author": {
+        "title": "Sobre o Autor",
+        "roles": "Escritor, artista e pesquisador independente",
+        "description": "Emanuel Souza é um escritor, artista e pesquisador independente. Seu trabalho abrange literatura, artes visuais e tecnologia blockchain, caracterizado pela experimentação formal, lirismo filosófico e profundo engajamento com o mundo contemporâneo.",
+        "technique": "Matzatea, seu segundo livro, consolida uma linguagem única desenvolvida ao longo dos últimos anos. A obra emprega uma 'técnica de exteriorização do presente', método de escrita que projeta para fora, conectando experiências subjetivas com fluxos coletivos, sonhos e eventos políticos. A narrativa mescla o real e o simbólico para criar espaços de pensamento e sensibilidade.",
+        "participations": "Sua participação no cenário artístico inclui presenças marcantes, como no NFT Brasil 2024, onde falou sobre sua obra literária no contexto das mídias descentralizadas, e no TokenNation 2025, onde apresentou seus trabalhos na intersecção entre literatura e Web3. Essas experiências destacam seu compromisso com formas inovadoras de circulação artística e o diálogo entre tradição e tecnologia.",
+        "final": "Emanuel Souza cria 'atmosferas' em vez de apenas contar histórias, focando em lugares de passagem, deslocamento e descoberta. Com Matzatea, convida o leitor a experimentar uma narrativa que é simultaneamente ficção, pensamento e um portal sensível para outra forma de estar no mundo."
+      },
+      "artist": {
+        "title": "Sobre a Artista",
+        "roles": "Artista, curadora e consultora de arte e Web3",
+        "description": "Fer Caggiano é uma artista, curadora e consultora de arte e Web3. Sua trajetória faz ponte entre as artes tradicionais e digitais, com trabalhos marcados pela exploração da cor, textura e temas como amor, liberdade e conexões humanas. Mantém uma perspectiva sensível sobre as transformações sociais e tecnológicas.",
+        "project": "No projeto Matzatea, Fer cria uma experiência artística imersiva que acompanha uma narrativa. Ela traduz conceitos e emoções de um livro em imagens e atmosferas visuais. Sua prática combina técnicas clássicas de pintura a óleo com experimentações digitais, promovendo um diálogo entre o físico e o virtual, expandindo a dimensão da obra de arte.",
+        "activities": "Através de residências artísticas, exposições internacionais e participação ativa no universo NFT, Fer reforça seu compromisso com a inovação e interdisciplinaridade na arte contemporânea. Em Matzatea, ela convida o público a experimentar um espaço sensorial onde literatura e arte visual se entrelaçam, expandindo as possibilidades de percepção e experiência."
+      },
+      "cultural_relevance": {
+        "title": "Relevância Cultural",
+        "intro": "Matzatea é uma experiência literária que combina o sensorial com o filosófico, inspirando-se no existencialismo para reavaliar o cotidiano urbano contemporâneo. Ambientado em um Rio de Janeiro vibrante e exausto, o trabalho convida o leitor a refletir sobre temas como liberdade, alienação e o sentido da existência diante da repetição, do ruído e da velocidade da vida moderna.",
+        "boundaries": "Ao explorar os limites entre o real e o absurdo, o romance engaja com questões profundas da subjetividade atual, criando conexões entre literatura, filosofia e tecnologia.",
+        "expansion": "Matzatea é mais que apenas uma obra impressa; expande-se em ações culturais formativas. Estas incluem oficinas literárias, encontros com leitores e educadores, distribuição gratuita de exemplares e uma edição digital acessível, utilizando recursos tecnológicos como NFTs e materiais interativos.",
+        "initiative": "A iniciativa valoriza a produção nacional, amplia o acesso à literatura e incentiva a reflexão crítica dentro da paisagem cultural contemporânea."
+      },
+      "funding": {
+        "title": "Um projeto que aproxima, provoca e transforma",
+        "subtitle": "Projeto viabilizado com apoio da Lei Rouanet",
+        "description": "Este projeto é realizado com incentivo da Lei Federal de Incentivo à Cultura — a Lei Rouanet. A proposta vai além do lançamento de um livro: inclui ações formativas, oficinas culturais, distribuição gratuita de exemplares físicos, versão digital acessível e a criação de espaços de diálogo entre autores, leitores, estudantes e educadores.",
+        "final": "Matzatea é um convite à criação, à partilha e à formação cultural."
+      },
+      "cta": {
+        "title": "Descubra Mais Projetos",
+        "description": "Explore outros projetos filosóficos, artísticos e tecnológicos do GIFLABS.",
+        "button": "Ver Todos os Projetos"
+      }
+    }
+  },
+  en: {
+    "matzatea": {
+      "back_to_home": "Back to Home",
+      "hero": {
+        "title": "Matzatea",
+        "subtitle": "A philosophical thriller that challenges reality",
+        "badges": {
+          "literary": "Literary",
+          "artistic": "Artistic",
+          "cultural": "Cultural"
+        }
+      },
+      "project": {
+        "title": "The Project",
+        "description": "Matzatea is more than a literary work; it's a cultural experience that articulates literature, visual arts, technology, and reader formation. Born from the desire to explore new forms of narration and connect with the public, the project proposes an aesthetic immersion that goes beyond the limits of the printed book.",
+        "context": "Starting from the eponymous novel, set in Rio de Janeiro in 1994, the project unfolds into actions that promote access to contemporary Brazilian literature, dialogue between different artistic languages, and the democratization of knowledge.",
+        "collaboration": "It features illustrations and scenarios specially created for the work by visual artist Fer Caggiano. Matzatea proposes a sensory and expanded reading where image and text intertwine to enhance the reader's experience. The art not only illustrates but also interprets and amplifies the meanings of the narrative.",
+        "actions": "The project includes the publication of the book in physical and digital versions, a series of cultural actions, including literary workshops, debates with the author, meetings with educators, pedagogical activities, and free distribution of copies to public libraries, schools, and social projects.",
+        "objectives": "These initiatives aim to stimulate critical thinking, encourage reading, and value independent literary production."
+      },
+      "author": {
+        "title": "About the Author",
+        "roles": "Writer, artist, and independent researcher",
+        "description": "Emanuel Souza is a writer, artist, and independent researcher. His work spans literature, visual arts, and blockchain technology, characterized by formal experimentation, philosophical lyricism, and deep engagement with the contemporary world.",
+        "technique": "Matzatea, his second book, consolidates a unique language developed over recent years. The work employs a 'technique of present exteriorization,' a writing method that projects outward, connecting subjective experiences with collective flows, dreams, and political events. The narrative blends the real and symbolic to create spaces for thought and sensibility.",
+        "participations": "His involvement in the art scene includes notable participations, such as NFT Brasil 2024, where he spoke about his literary work in the context of decentralized media, and TokenNation 2025, where he presented his works at the intersection of literature and Web3. These experiences highlight his commitment to innovative forms of art circulation and dialogue between tradition and technology.",
+        "final": "Emanuel Souza creates 'atmospheres' rather than just telling stories, focusing on places of passage, displacement, and discovery. With Matzatea, he invites the reader to experience a narrative that is simultaneously fiction, thought, and a sensitive portal to another way of being in the world."
+      },
+      "artist": {
+        "title": "About the Artist",
+        "roles": "Artist, curator, and art and Web3 consultant",
+        "description": "Fer Caggiano is an artist, curator, and art and Web3 consultant. Her trajectory bridges traditional and digital arts, with works marked by the exploration of color, texture, and themes such as love, freedom, and human connections. She maintains a sensitive perspective on social and technological transformations.",
+        "project": "In the Matzatea project, Fer creates an immersive artistic experience that accompanies a narrative. She translates concepts and emotions from a book into images and visual atmospheres. Her practice combines classical oil painting techniques with digital experimentations, promoting dialogue between the physical and virtual, expanding the dimension of the artwork.",
+        "activities": "Through artistic residencies, international exhibitions, and active participation in the NFT universe, Fer reinforces her commitment to innovation and interdisciplinarity in contemporary art. In Matzatea, she invites the public to experience a sensory space where literature and visual art intertwine, expanding the possibilities of perception and experience."
+      },
+      "cultural_relevance": {
+        "title": "Cultural Relevance",
+        "intro": "Matzatea is a literary experience that combines the sensory with the philosophical, drawing inspiration from existentialism to re-evaluate contemporary urban daily life. Set in a vibrant and exhausted Rio de Janeiro, the work invites readers to reflect on themes such as freedom, alienation, and the meaning of existence in the face of repetition, noise, and the speed of modern life.",
+        "boundaries": "By exploring the boundaries between the real and the absurd, the novel engages with profound questions of current subjectivity, creating connections between literature, philosophy, and technology.",
+        "expansion": "Matzatea is more than just a printed work; it expands into formative cultural activities. These include literary workshops, meetings with readers and educators, free distribution of physical copies, and an accessible digital edition utilizing technological resources such as NFTs and interactive materials.",
+        "initiative": "The initiative values national production, broadens access to literature, and encourages critical reflection within the contemporary cultural landscape."
+      },
+      "funding": {
+        "title": "A project that brings closer, provokes, and transforms",
+        "subtitle": "Project made possible with the support of the Rouanet Law",
+        "description": "This project is carried out with the incentive of the Federal Law of Incentive to Culture — the Rouanet Law. The proposal goes beyond the launch of a book: it includes formative actions, cultural workshops, free distribution of physical copies, accessible digital version, and the creation of dialogue spaces between authors, readers, students, and educators.",
+        "final": "Matzatea is an invitation to creation, sharing, and cultural formation."
+      },
+      "cta": {
+        "title": "Discover More Projects",
+        "description": "Explore other philosophical, artistic, and technological projects from GIFLABS.",
+        "button": "View All Projects"
+      }
+    }
+  }
+};


### PR DESCRIPTION
Introduces the Matzatea project with a new dedicated page, translation entries in both Portuguese and English, and updates to the project list. Also adds project documentation files (.cursorrules, PROJECT_STRUCTURE.md) and imports Matzatea translations into the LanguageContext.